### PR TITLE
FIX: Object's now properly appear level on plane (z-axis)

### DIFF
--- a/simian/object.py
+++ b/simian/object.py
@@ -493,22 +493,26 @@ def set_pivot_to_bottom(obj: bpy.types.Object) -> None:
     # Calculate the center of mass
     bpy.context.view_layer.update()
     center_of_mass = obj.location
+    print("Center of mass:", center_of_mass)
 
-    # Calculate the bounding box bottom
     bbox_min = [obj.matrix_world @ Vector(corner) for corner in obj.bound_box][0]
     for corner in obj.bound_box:
         world_corner = obj.matrix_world @ Vector(corner)
         if world_corner.z < bbox_min.z:
             bbox_min = world_corner
+    print("Bounding box bottom:", bbox_min)
 
-    # Set origin to the center of mass, then adjust Z-coordinate to the bottom of the bounding box
     bpy.ops.object.origin_set(type="ORIGIN_CENTER_OF_MASS", center="BOUNDS")
+    print("After setting origin to center of mass:", obj.location)
+
     obj.location.z = center_of_mass.z - bbox_min.z
     obj.location.y = 0
     obj.location.x = 0
+    print("After adjusting location:", obj.location)
 
     bpy.context.scene.cursor.location = (0, 0, 0)
     bpy.ops.object.origin_set(type="ORIGIN_CURSOR")
+    print("After setting origin to cursor:", obj.location)
 
 
 def unparent_keep_transform(obj: bpy.types.Object) -> None:
@@ -522,14 +526,16 @@ def unparent_keep_transform(obj: bpy.types.Object) -> None:
         None
     """
     # Check if the parent object has a negative scale in the z-axis
-    if obj.parent and obj.parent.scale.z < 0:
+    # if obj.parent and obj.parent.scale.z < 0:
+    #     # Unparent the object
+    #     bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
+    #     # Invert the z-scale of the object to maintain its original z-scale
+    #     obj.scale.z *= -1
+    # else:
         # Unparent the object
-        bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
-        # Invert the z-scale of the object to maintain its original z-scale
-        obj.scale.z *= -1
-    else:
-        # Unparent the object
-        bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
+    print("Before unparent_keep_transform:", obj.location, obj.scale)
+    bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
+    print("After unparent_keep_transform:", obj.location, obj.scale)
 
 
 def delete_all_empties() -> None:

--- a/simian/object.py
+++ b/simian/object.py
@@ -521,8 +521,15 @@ def unparent_keep_transform(obj: bpy.types.Object) -> None:
     Returns:
         None
     """
-    # clear the parent object, but keep the transform
-    bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
+    # Check if the parent object has a negative scale in the z-axis
+    if obj.parent and obj.parent.scale.z < 0:
+        # Unparent the object
+        bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
+        # Invert the z-scale of the object to maintain its original z-scale
+        obj.scale.z *= -1
+    else:
+        # Unparent the object
+        bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
 
 
 def delete_all_empties() -> None:

--- a/simian/object.py
+++ b/simian/object.py
@@ -526,16 +526,14 @@ def unparent_keep_transform(obj: bpy.types.Object) -> None:
         None
     """
     # Check if the parent object has a negative scale in the z-axis
-    # if obj.parent and obj.parent.scale.z < 0:
-    #     # Unparent the object
-    #     bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
-    #     # Invert the z-scale of the object to maintain its original z-scale
-    #     obj.scale.z *= -1
-    # else:
+    if obj.parent and obj.parent.scale.z < 0:
         # Unparent the object
-    print("Before unparent_keep_transform:", obj.location, obj.scale)
-    bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
-    print("After unparent_keep_transform:", obj.location, obj.scale)
+        bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
+        # Invert the z-scale of the object to maintain its original z-scale
+        obj.scale.z *= -1
+    else:
+        # Unparent the object
+        bpy.ops.object.parent_clear(type="CLEAR_KEEP_TRANSFORM")
 
 
 def delete_all_empties() -> None:

--- a/simian/render.py
+++ b/simian/render.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
     # Render the images
     render_scene(
         start_frame=args.start_frame,
-        end_frame=3,
+        end_frame=args.end_frame,
         output_dir=args.output_dir,
         context=context,
         combination_file=args.combination_file,

--- a/simian/render.py
+++ b/simian/render.py
@@ -118,67 +118,23 @@ def render_scene(
         load_object(object_file)
         obj = [obj for obj in context.view_layer.objects.selected][0]
 
-        print("Before apply_and_remove_armatures:", obj.location)
         apply_and_remove_armatures()
-        print("After apply_and_remove_armatures:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after apply_and_remove_armatures")
-
-        print("Before apply_all_modifiers:", obj.location)
         apply_all_modifiers(obj)
-        print("After apply_all_modifiers:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after apply_all_modifiers")
-
-        print("Before join_objects_in_hierarchy:", obj.location)
         join_objects_in_hierarchy(obj)
-        print("After join_objects_in_hierarchy:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after join_objects_in_hierarchy")
-
-        print("Before optimize_meshes_in_hierarchy:", obj.location)
         optimize_meshes_in_hierarchy(obj)
-        print("After optimize_meshes_in_hierarchy:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after optimize_meshes_in_hierarchy")
-
-        print("Before remove_loose_meshes:", obj.location)
         remove_loose_meshes(obj)
-        print("After remove_loose_meshes:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after remove_loose_meshes")
 
         meshes = get_meshes_in_hierarchy(obj)
         obj = meshes[0]
-        print("After get_meshes_in_hierarchy:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after get_meshes_in_hierarchy")
 
         if focus_object is None:
             focus_object = obj
-
-        print("Before unparent_keep_transform:", obj.location)
+        
         unparent_keep_transform(obj)
-        print("After unparent_keep_transform:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after unparent_keep_transform")
-
-        print("Before set_pivot_to_bottom:", obj.location)
         set_pivot_to_bottom(obj)
-        print("After set_pivot_to_bottom:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after set_pivot_to_bottom")
 
         obj.scale = [object_data["scale"]["factor"] for _ in range(3)]
-        print("After setting scale:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after setting scale")
-
-        print("Before normalize_object_scale:", obj.location)
         normalize_object_scale(obj)
-        print("After normalize_object_scale:", obj.location)
-        if obj.location.z < 0:
-            print("Z value is negative after normalize_object_scale")
 
         obj.name = object_data["uid"]  # Set the Blender object's name to the UID
 
@@ -299,7 +255,7 @@ if __name__ == "__main__":
     # Render the images
     render_scene(
         start_frame=args.start_frame,
-        end_frame=args.end_frame,
+        end_frame=3,
         output_dir=args.output_dir,
         context=context,
         combination_file=args.combination_file,

--- a/simian/render.py
+++ b/simian/render.py
@@ -118,23 +118,55 @@ def render_scene(
         load_object(object_file)
         obj = [obj for obj in context.view_layer.objects.selected][0]
 
+        print(f"Object rotation before apply_and_remove_armatures: {obj.rotation_euler}")
         apply_and_remove_armatures()
+        print(f"Object rotation after apply_and_remove_armatures: {obj.rotation_euler}")
+
+        print(f"Object rotation before apply_all_modifiers: {obj.rotation_euler}")
         apply_all_modifiers(obj)
+        print(f"Object rotation after apply_all_modifiers: {obj.rotation_euler}")
+
+        print(f"Object rotation before join_objects_in_hierarchy: {obj.rotation_euler}")
         join_objects_in_hierarchy(obj)
+        print(f"Object rotation after join_objects_in_hierarchy: {obj.rotation_euler}")
+
+        print(f"Object rotation before optimize_meshes_in_hierarchy: {obj.rotation_euler}")
         optimize_meshes_in_hierarchy(obj)
+        print(f"Object rotation after optimize_meshes_in_hierarchy: {obj.rotation_euler}")
+
+        print(f"Object rotation before remove_loose_meshes: {obj.rotation_euler}")
         remove_loose_meshes(obj)
+        print(f"Object rotation after remove_loose_meshes: {obj.rotation_euler}")
 
         meshes = get_meshes_in_hierarchy(obj)
         obj = meshes[0]
+
+        if obj.scale.z < 0:
+            obj.scale.z *= -1
+
+        print(f"Object rotation after get_meshes_in_hierarchy: {obj.rotation_euler}")
+        print(f"Object scale after get_meshes_in_hierarchy: {obj.scale}")
 
         if focus_object is None:
             focus_object = obj
 
         unparent_keep_transform(obj)
+
+        if obj.scale.z < 0:
+            obj.scale.z *= -1
+        print(f"Object rotation after unparent_keep_transform: {obj.rotation_euler}")
+        print(f"Object scale after unparent_keep_transform: {obj.scale}")
+
         set_pivot_to_bottom(obj)
+        print(f"Object rotation after set_pivot_to_bottom: {obj.rotation_euler}")
+        print(f"Object scale after set_pivot_to_bottom: {obj.scale}")
 
         obj.scale = [object_data["scale"]["factor"] for _ in range(3)]
+        print(f"Object scale after setting scale: {obj.scale}")
+
         normalize_object_scale(obj)
+        print(f"Object rotation after normalize_object_scale: {obj.rotation_euler}")
+        print(f"Object scale after normalize_object_scale: {obj.scale}")
 
         obj.name = object_data["uid"]  # Set the Blender object's name to the UID
 
@@ -255,7 +287,7 @@ if __name__ == "__main__":
     # Render the images
     render_scene(
         start_frame=args.start_frame,
-        end_frame=args.end_frame,
+        end_frame=3,
         output_dir=args.output_dir,
         context=context,
         combination_file=args.combination_file,

--- a/simian/render.py
+++ b/simian/render.py
@@ -118,55 +118,23 @@ def render_scene(
         load_object(object_file)
         obj = [obj for obj in context.view_layer.objects.selected][0]
 
-        print(f"Object rotation before apply_and_remove_armatures: {obj.rotation_euler}")
         apply_and_remove_armatures()
-        print(f"Object rotation after apply_and_remove_armatures: {obj.rotation_euler}")
-
-        print(f"Object rotation before apply_all_modifiers: {obj.rotation_euler}")
         apply_all_modifiers(obj)
-        print(f"Object rotation after apply_all_modifiers: {obj.rotation_euler}")
-
-        print(f"Object rotation before join_objects_in_hierarchy: {obj.rotation_euler}")
         join_objects_in_hierarchy(obj)
-        print(f"Object rotation after join_objects_in_hierarchy: {obj.rotation_euler}")
-
-        print(f"Object rotation before optimize_meshes_in_hierarchy: {obj.rotation_euler}")
         optimize_meshes_in_hierarchy(obj)
-        print(f"Object rotation after optimize_meshes_in_hierarchy: {obj.rotation_euler}")
-
-        print(f"Object rotation before remove_loose_meshes: {obj.rotation_euler}")
         remove_loose_meshes(obj)
-        print(f"Object rotation after remove_loose_meshes: {obj.rotation_euler}")
 
         meshes = get_meshes_in_hierarchy(obj)
         obj = meshes[0]
 
-        if obj.scale.z < 0:
-            obj.scale.z *= -1
-
-        print(f"Object rotation after get_meshes_in_hierarchy: {obj.rotation_euler}")
-        print(f"Object scale after get_meshes_in_hierarchy: {obj.scale}")
-
         if focus_object is None:
             focus_object = obj
-
+        
         unparent_keep_transform(obj)
-
-        if obj.scale.z < 0:
-            obj.scale.z *= -1
-        print(f"Object rotation after unparent_keep_transform: {obj.rotation_euler}")
-        print(f"Object scale after unparent_keep_transform: {obj.scale}")
-
         set_pivot_to_bottom(obj)
-        print(f"Object rotation after set_pivot_to_bottom: {obj.rotation_euler}")
-        print(f"Object scale after set_pivot_to_bottom: {obj.scale}")
 
         obj.scale = [object_data["scale"]["factor"] for _ in range(3)]
-        print(f"Object scale after setting scale: {obj.scale}")
-
         normalize_object_scale(obj)
-        print(f"Object rotation after normalize_object_scale: {obj.rotation_euler}")
-        print(f"Object scale after normalize_object_scale: {obj.scale}")
 
         obj.name = object_data["uid"]  # Set the Blender object's name to the UID
 
@@ -287,7 +255,7 @@ if __name__ == "__main__":
     # Render the images
     render_scene(
         start_frame=args.start_frame,
-        end_frame=3,
+        end_frame=args.end_frame,
         output_dir=args.output_dir,
         context=context,
         combination_file=args.combination_file,

--- a/simian/render.py
+++ b/simian/render.py
@@ -118,23 +118,67 @@ def render_scene(
         load_object(object_file)
         obj = [obj for obj in context.view_layer.objects.selected][0]
 
+        print("Before apply_and_remove_armatures:", obj.location)
         apply_and_remove_armatures()
+        print("After apply_and_remove_armatures:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after apply_and_remove_armatures")
+
+        print("Before apply_all_modifiers:", obj.location)
         apply_all_modifiers(obj)
+        print("After apply_all_modifiers:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after apply_all_modifiers")
+
+        print("Before join_objects_in_hierarchy:", obj.location)
         join_objects_in_hierarchy(obj)
+        print("After join_objects_in_hierarchy:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after join_objects_in_hierarchy")
+
+        print("Before optimize_meshes_in_hierarchy:", obj.location)
         optimize_meshes_in_hierarchy(obj)
+        print("After optimize_meshes_in_hierarchy:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after optimize_meshes_in_hierarchy")
+
+        print("Before remove_loose_meshes:", obj.location)
         remove_loose_meshes(obj)
+        print("After remove_loose_meshes:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after remove_loose_meshes")
 
         meshes = get_meshes_in_hierarchy(obj)
         obj = meshes[0]
+        print("After get_meshes_in_hierarchy:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after get_meshes_in_hierarchy")
 
         if focus_object is None:
             focus_object = obj
-        
+
+        print("Before unparent_keep_transform:", obj.location)
         unparent_keep_transform(obj)
+        print("After unparent_keep_transform:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after unparent_keep_transform")
+
+        print("Before set_pivot_to_bottom:", obj.location)
         set_pivot_to_bottom(obj)
+        print("After set_pivot_to_bottom:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after set_pivot_to_bottom")
 
         obj.scale = [object_data["scale"]["factor"] for _ in range(3)]
+        print("After setting scale:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after setting scale")
+
+        print("Before normalize_object_scale:", obj.location)
         normalize_object_scale(obj)
+        print("After normalize_object_scale:", obj.location)
+        if obj.location.z < 0:
+            print("Z value is negative after normalize_object_scale")
 
         obj.name = object_data["uid"]  # Set the Blender object's name to the UID
 


### PR DESCRIPTION
Object's are no longer appear inverted below the z-axis (poor raccoon was underground before) :white_check_mark:
Before some videos would not appear in the video.

This is due to some objects actually being placed/transformed underground.
Why is this happening? This is due to negative scale factor. When you scale an object by a negative factor, it inverts the object along that axis and it's occurring because the object is inheriting a negative scale from the parent.

Fix unparent_keep_transform function