### PR TITLE
Refactor CLI, refactor package into module form and change commands for starting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,10 @@ jobs:
       run: bash scripts/get_data.sh
 
     - name: Generate combinations
-      run: python3.11 simian/combiner.py
+      run: python3.11 -m simian.combiner
 
     - name: Run tests
-      run: python3.11 tests/__run__.py
+      run: python3.11 -m simian.tests.__run__
 
     - name: Check test results
       if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ venv/
 .env
 version.txt
 dist
+config.json

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sudo python3 scripts/start_x_server.py start
 ### Generating Combinations
 
 ```bash
-python3 simian/combiner.py --count 1000 --seed 42
+python3 -m simian.combiner --count 1000 --seed 42
 ```
 
 ### Generating Videos or Images
@@ -59,12 +59,12 @@ Or generate all or part of the combination set using the `batch.py` script:
 
 To generate a video(s): 
 ```bash
-python3 simian/batch.py --start_index 0 --end_index 1000 --width 1024 --height 576 --start_frame 1 --end_frame 65 --animation_length 120
+python3 -m simian.batch --start_index 0 --end_index 1000 --width 1024 --height 576 --start_frame 1 --end_frame 65 --animation_length 120
 ```
 
 To generate an image(s):
 ```bash
-python3 simian/batch.py --start_index 0 --end_index 1000 --width 1024 --height 576 --start_frame 1 --end_frame 65 --animation_length 120 --images
+python3 -m simian.batch --start_index 0 --end_index 1000 --width 1024 --height 576 --start_frame 1 --end_frame 65 --animation_length 120 --images
 ```
 
 
@@ -120,7 +120,7 @@ docker run -e REDIS_HOST={myhost} -e REDIS_PORT={port} -e REDIS_USER=default -e 
 Finally, issue work to your task queue
 
 ```bash
-python3 simian/simian.py --start_index 0 --end_index 10 --width 1024 --height 576
+python3 -m simian.cli --start_index 0 --end_index 10 --width 1024 --height 576
 ```
 
 If you want to use a custom or hosted Redis instance (recommended), you can add the redis details like this:
@@ -131,10 +131,16 @@ export REDIS_USER=default
 export REDIS_PASSWORD=<somepassword>
 ```
 
+To run all tests
+
+```
+python3 -m simian.tests.__run__
+```
+
 To run tests look into the test folder and run whichever test file you want
 
 ```bash
-python object_test.py
+python3 -m simian.tests.object_test
 ```
 
 ## 📁 Datasets

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ sudo python3 scripts/start_x_server.py start
 ### Generating Combinations
 
 ```bash
-python3 simian/combiner.py --count 1000 --seed 42
+python3 -m simian.combiner --count 1000 --seed 42
 ```
 
 ### Generating Videos
@@ -36,13 +36,13 @@ python3 simian/combiner.py --count 1000 --seed 42
 You can generate individually:
 ```bash
 # MacOS
-python simian/render.py
+python -m simian.render
 
 # Linux
-python simian/render.py
+python -m simian.render
 
 ## Kitchen sink
-python simian/render.py -- --width 1920 --height 1080 --combination_index 0 --output_dir ./renders --hdri_path ./backgrounds --start_frame 1 --end_frame 65
+python -m simian.render -- --width 1920 --height 1080 --combination_index 0 --output_dir ./renders --hdri_path ./backgrounds --start_frame 1 --end_frame 65
 ```
 
 Configure the flags as needed:
@@ -55,7 +55,7 @@ Configure the flags as needed:
 Or generate all or part of the combination set using the `batch.py` script:
 
 ```bash
-python3 simian/batch.py --start_index 0 --end_index 1000 --width 1024 --height 576 --start_frame 1 --end_frame 65
+python3 -m simian.batch --start_index 0 --end_index 1000 --width 1024 --height 576 --start_frame 1 --end_frame 65
 ```
 
 ### Clean up Captions
@@ -110,7 +110,7 @@ docker run -e REDIS_HOST={myhost} -e REDIS_PORT={port} -e REDIS_USER=default -e 
 Finally, issue work to your task queue
 
 ```bash
-python3 simian/simian.py --start_index 0 --end_index 10 --width 1024 --height 576
+python3 -m simian.cli --start_index 0 --end_index 10 --width 1024 --height 576
 ```
 
 If you want to use a custom or hosted Redis instance (recommended), you can add the redis details like this:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+omegaconf==2.0.5
 requests
 argparse
 numpy

--- a/simian/batch.py
+++ b/simian/batch.py
@@ -1,16 +1,10 @@
 import json
 import multiprocessing
 import os
-import platform
-import random
 import subprocess
 import sys
 import argparse
 from typing import Optional
-
-# Append Simian to sys.path before importing from package
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../"))
-
 
 def render_objects(
     processes: Optional[int] = None,
@@ -77,7 +71,7 @@ def render_objects(
         else:
             args = f"--width {width} --height {height} --combination_index {i} --start_frame {start_frame} --end_frame {end_frame} --output_dir {target_directory} --hdri_path {hdri_path} --animation_length {animation_length}"
 
-        command = f"{sys.executable} simian/render.py -- {args}"
+        command = f"{sys.executable} -m simian.render -- {args}"
         subprocess.run(["bash", "-c", command], timeout=render_timeout, check=False)
 
 

--- a/simian/cli.py
+++ b/simian/cli.py
@@ -112,6 +112,8 @@ if __name__ == "__main__":
         max_nodes = job_config["max_nodes"]
         docker_image = "arfx/simian-worker:latest"
 
+        print("MAX PRICE: ", max_price)
+        print("SEARCHING FOR NODES...")
         num_nodes_avail = len(distributaur.search_offers(max_price))
         print("TOTAL NODES AVAILABLE: ", num_nodes_avail)
 

--- a/simian/cli.py
+++ b/simian/cli.py
@@ -1,41 +1,23 @@
 import argparse
+import json
 import logging
 import os
 import signal
 import sys
 import time
-import json
 from typing import Dict
+
+from distributaur.distributaur import Distributaur
+
+from .worker import run_job
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../"))
-
 if __name__ == "__main__":
 
-    from distributaur.core import (
-        execute_function,
-        get_env_vars,
-        redis_client,
-        check_job_status,
-        attach_to_existing_job,
-        monitor_job_status,
-    )
-
-    from distributaur.vast import rent_nodes, terminate_nodes, handle_signal
-
-    from simian.worker import *
-
     def get_env_vars(path: str = ".env") -> Dict[str, str]:
-        """Get the environment variables from the specified file.
-
-        Args:
-            path (str): The path to the file containing the environment variables. Defaults to ".env".
-
-        Returns:
-            Dict[str, str]: A dictionary containing the environment variables.
-        """
+        """Get the environment variables from the specified file."""
         env_vars = {}
         if not os.path.exists(path):
             return env_vars
@@ -61,8 +43,6 @@ if __name__ == "__main__":
             "hdri_path": args.hdri_path or env_vars.get("HDRI_PATH", "./backgrounds"),
             "max_price": args.max_price or float(env_vars.get("MAX_PRICE", 0.1)),
             "max_nodes": args.max_nodes or int(env_vars.get("MAX_NODES", 1)),
-            "image": args.image
-            or env_vars.get("DOCKER_IMAGE", "arfx/simian-worker:latest"),
             "api_key": args.api_key or env_vars.get("VAST_API_KEY", ""),
             "redis_host": args.redis_host or env_vars.get("REDIS_HOST", "localhost"),
             "redis_port": args.redis_port or int(env_vars.get("REDIS_PORT", 6379)),
@@ -80,12 +60,74 @@ if __name__ == "__main__":
 
         return settings
 
-    def setup_and_run(job_config):
+    def start_new_job(args):
+        logger.info("Starting a new job...")
+        settings = get_settings(args)
+
+        # Override environment variables with provided arguments
+        os.environ["REDIS_HOST"] = args.redis_host or settings["redis_host"]
+        os.environ["REDIS_PORT"] = str(args.redis_port or settings["redis_port"])
+        os.environ["REDIS_USER"] = args.redis_user or settings["redis_user"]
+        os.environ["REDIS_PASSWORD"] = args.redis_password or settings["redis_password"]
+        os.environ["HF_TOKEN"] = args.hf_token or settings["hf_token"]
+        os.environ["HF_REPO_ID"] = args.hf_repo_id or settings["hf_repo_id"]
+        os.environ["HF_PATH"] = args.hf_path or settings["hf_path"]
+
+        job_config = {
+            "max_price": settings["max_price"],
+            "max_nodes": settings["max_nodes"],
+            "start_index": settings["start_index"],
+            "end_index": settings["end_index"],
+            "combinations": settings["combinations"],
+            "width": settings["width"],
+            "height": settings["height"],
+            "output_dir": settings["output_dir"],
+            "hdri_path": settings["hdri_path"],
+            "start_frame": settings["start_frame"],
+            "end_frame": settings["end_frame"],
+            "api_key": settings["api_key"],
+            "hf_token": settings["hf_token"],
+            "hf_repo_id": settings["hf_repo_id"],
+            "hf_path": settings["hf_path"],
+            "redis_host": settings["redis_host"],
+            "redis_port": settings["redis_port"],
+            "redis_user": settings["redis_user"],
+            "redis_password": settings["redis_password"],
+        }
+        
+        print('*** JOB CONFIG')
+        print(job_config)
+
+        distributaur = Distributaur(
+            hf_repo_id=job_config["hf_repo_id"],
+            hf_token=job_config["hf_token"],
+            vast_api_key=job_config["api_key"],
+            redis_host=job_config["redis_host"],
+            redis_port=job_config["redis_port"],
+            redis_username=job_config["redis_user"],
+            redis_password=job_config["redis_password"],
+        )
+
+        max_price = job_config["max_price"]
+        max_nodes = job_config["max_nodes"]
+        docker_image = "arfx/simian-worker:latest"
+
+        num_nodes_avail = len(distributaur.search_offers(max_price))
+        print("TOTAL NODES AVAILABLE: ", num_nodes_avail)
+
+        rented_nodes = distributaur.rent_nodes(max_price, max_nodes, docker_image)
+
+        print("TOTAL RENTED NODES: ", len(rented_nodes))
+        print(rented_nodes)
+
+        distributaur.register_function(run_job)
+        distributaur.start_monitoring_server(worker_name="simian.worker")
+
         tasks = []
-        # combination_index should be max of the length of the combinations and the end index
-        end_index = min(len(job_config["combinations"]), job_config["end_index"])
-        for combination_index in range(job_config["start_index"], end_index):
-            task = execute_function(
+
+        # Submit tasks
+        for combination_index in range(job_config["start_index"], min(job_config["end_index"], len(job_config["combinations"]))):
+            task = distributaur.execute_function(
                 "run_job",
                 {
                     "combination_index": combination_index,
@@ -100,154 +142,41 @@ if __name__ == "__main__":
             )
             tasks.append(task)
 
-        for task in tasks:
-            logger.info(f"Task {task.id} dispatched.")
-
+        # Wait for tasks to complete
+        print("Tasks submitted to queue. Waiting for tasks to complete...")
         while not all(task.ready() for task in tasks):
             time.sleep(1)
 
-        logger.info("All tasks have been completed!")
-
-    def start_new_job(args):
-        logger.info("Starting a new job...")
-        settings = get_settings(args)
-        job_id = args.job_id or input("Enter a unique job ID: ")
-
-        # Override environment variables with provided arguments
-        os.environ["REDIS_HOST"] = args.redis_host or settings["redis_host"]
-        os.environ["REDIS_PORT"] = str(args.redis_port or settings["redis_port"])
-        os.environ["REDIS_USER"] = args.redis_user or settings["redis_user"]
-        os.environ["REDIS_PASSWORD"] = args.redis_password or settings["redis_password"]
-        os.environ["HF_TOKEN"] = args.hf_token or settings["hf_token"]
-        os.environ["HF_REPO_ID"] = args.hf_repo_id or settings["hf_repo_id"]
-        os.environ["HF_PATH"] = args.hf_path or settings["hf_path"]
-
-        logger.info("Renting nodes on Vast.ai...")
-        # Rent nodes from vast.ai
-        nodes = rent_nodes(
-            max_price=settings["max_price"],
-            max_nodes=settings["max_nodes"],
-            image=settings["image"],
-            api_key=settings["api_key"],
-        )
-        logger.info("Nodes rented successfully!")
-
-        # Set up signal handler for graceful shutdown
-        signal_handler = handle_signal(nodes)
-        signal.signal(signal.SIGINT, signal_handler)
-
-        logger.info("Configuring distributed jobs...")
-
-        job_config = {
-            "job_id": job_id,
-            "max_price": settings["max_price"],
-            "max_nodes": settings["max_nodes"],
-            "docker_image": settings["image"],
-            "start_index": settings["start_index"],
-            "end_index": settings["end_index"],
-            "combinations": settings["combinations"],
-            "width": settings["width"],
-            "height": settings["height"],
-            "output_dir": settings["output_dir"],
-            "hdri_path": settings["hdri_path"],
-            "start_frame": settings["start_frame"],
-            "end_frame": settings["end_frame"],
-        }
-
-        # Check if the job is already running
-        if attach_to_existing_job(job_id):
-            logger.info("Attaching to an existing job...")
-            # Monitor job status and handle success/failure conditions
-            monitor_job_status(job_id)
-        else:
-            logger.info("Setting up and running the job...")
-            # Run the job
-            setup_and_run(job_config)
-            # Monitor job status and handle success/failure conditions
-            monitor_job_status(job_id)
-        logger.info("Job completed!")
-        # Terminate the rented nodes
-        terminate_nodes(nodes)
+        print("All tasks have been completed!")
+        distributaur.terminate_nodes(rented_nodes)
 
     def main():
         parser = argparse.ArgumentParser(description="Simian CLI")
-        # boolean
-        parser.add_argument("--list", action="store_true", help="List existing jobs")
-        parser.add_argument("--job-id", help="Unique job ID")
         parser.add_argument(
             "--start-index", type=int, help="Starting index for rendering"
         )
         parser.add_argument(
             "--combinations-file", help="Path to the combinations JSON file"
         )
-        parser.add_argument("--end_index", type=int, help="Ending index for rendering")
-        parser.add_argument("--start_frame", type=int, help="Starting frame number")
-        parser.add_argument("--end_frame", type=int, help="Ending frame number")
+        parser.add_argument("--end-index", type=int, help="Ending index for rendering")
+        parser.add_argument("--start-frame", type=int, help="Starting frame number")
+        parser.add_argument("--end-frame", type=int, help="Ending frame number")
         parser.add_argument("--width", type=int, help="Rendering width in pixels")
         parser.add_argument("--height", type=int, help="Rendering height in pixels")
-        parser.add_argument("--output_dir", help="Output directory")
+        parser.add_argument("--output-dir", help="Output directory")
         parser.add_argument("--hdri-path", help="HDRI path")
-        parser.add_argument("--max_price", type=float, help="Maximum price per hour")
-        parser.add_argument("--max_nodes", type=int, help="Maximum number of nodes")
-        parser.add_argument("--image", help="Docker image")
-        parser.add_argument("--api_key", help="Vast.ai API key")
-        parser.add_argument("--redis_host", help="Redis host")
-        parser.add_argument("--redis_port", type=int, help="Redis port")
-        parser.add_argument("--redis_user", help="Redis user")
-        parser.add_argument("--redis_password", help="Redis password")
-        parser.add_argument("--hf_token", help="Hugging Face token")
-        parser.add_argument("--hf_repo_id", help="Hugging Face repository ID")
-        parser.add_argument("--hf_path", help="Hugging Face path")
+        parser.add_argument("--max-price", type=float, help="Maximum price per hour")
+        parser.add_argument("--max-nodes", type=int, help="Maximum number of nodes")
+        parser.add_argument("--api-key", help="Vast.ai API key")
+        parser.add_argument("--redis-host", help="Redis host")
+        parser.add_argument("--redis-port", type=int, help="Redis port")
+        parser.add_argument("--redis-user", help="Redis user")
+        parser.add_argument("--redis-password", help="Redis password")
+        parser.add_argument("--hf-token", help="Hugging Face token")
+        parser.add_argument("--hf-repo-id", help="Hugging Face repository ID")
+        parser.add_argument("--hf-path", help="Hugging Face path")
         args = parser.parse_args()
 
-        if args.list is True:
-            list_jobs()
-        else:
-            start_new_job(args)
-
-    def list_jobs():
-        job_keys = redis_client.keys("celery-task-meta-*")
-        jobs = {}
-        for key in job_keys:
-            job_id = key.decode("utf-8").split("-")[-1]
-            if job_id not in jobs:
-                jobs[job_id] = check_job_status(job_id)
-
-        if not jobs:
-            logger.info("No existing jobs found.")
-            return
-
-        logger.info("Existing jobs:")
-        for job_id, status_counts in jobs.items():
-            logger.info(f"Job ID: {job_id}")
-            logger.info(f"Status: {status_counts}")
-
-        while True:
-            selection = input(
-                "Enter a job ID to attach to, 'd' to delete a job, 'c' to clear all jobs, or 'q' to quit: "
-            )
-            if selection == "q":
-                break
-            elif selection == "c":
-                confirm = input("Are you sure you want to clear all jobs? (y/n): ")
-                if confirm.lower() == "y":
-                    redis_client.flushdb()
-                    logger.info("All jobs cleared.")
-                break
-            elif selection == "d":
-                job_id = input("Enter the job ID to delete: ")
-                if job_id in jobs:
-                    keys = redis_client.keys(f"celery-task-meta-*{job_id}")
-                    for key in keys:
-                        redis_client.delete(key)
-                    logger.info(f"Job {job_id} deleted.")
-                else:
-                    logger.info(f"Job {job_id} not found.")
-            elif selection in jobs:
-                logger.info(f"Attaching to job {selection}...")
-                sys.argv = [sys.argv[0], "--job-id", selection]
-                break
-            else:
-                logger.info("Invalid selection.")
+        start_new_job(args)
 
     main()

--- a/simian/combiner.py
+++ b/simian/combiner.py
@@ -4,12 +4,9 @@ import math
 import os
 import random
 import argparse
-import sys
 from typing import Any, Dict, List, Optional
 
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../"))
-
-from simian.transform import determine_relationships, adjust_positions
+from .transform import determine_relationships, adjust_positions
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)

--- a/simian/render.py
+++ b/simian/render.py
@@ -12,23 +12,14 @@ logger = logging.getLogger(__name__)
 
 ssl._create_default_https_context = ssl._create_unverified_context
 
-# Get the directory of the currently executing script
-current_dir = os.path.dirname(os.path.abspath(__file__))
-
-# if the directory is simian, remove that
-if current_dir.endswith("simian"):
-    current_dir = os.path.dirname(current_dir)
-
-sys.path.append(os.path.join(current_dir))
-
-from simian.camera import (
+from .camera import (
     create_camera_rig,
     position_camera,
     set_camera_animation,
     set_camera_settings,
 )
-from simian.transform import find_largest_length, place_objects_on_grid
-from simian.object import (
+from .transform import find_largest_length, place_objects_on_grid
+from .object import (
     apply_all_modifiers,
     apply_and_remove_armatures,
     get_meshes_in_hierarchy,
@@ -41,10 +32,9 @@ from simian.object import (
     unlock_objects,
     unparent_keep_transform,
 )
-from simian.background import create_photosphere, set_background
-from simian.scene import apply_stage_material, create_stage, initialize_scene
-import simian.vendor.objaverse
-
+from .background import create_photosphere, set_background
+from .scene import apply_stage_material, create_stage, initialize_scene
+from .vendor import objaverse
 
 def read_combination(combination_file: str, index: int = 0) -> dict:
     """
@@ -114,7 +104,7 @@ def render_scene(
     focus_object = None
 
     for object_data in combination["objects"]:
-        object_file = simian.vendor.objaverse.load_objects([object_data["uid"]])[
+        object_file = objaverse.load_objects([object_data["uid"]])[
             object_data["uid"]
         ]
 
@@ -288,7 +278,7 @@ if __name__ == "__main__":
     for object in objects_column:
         uid = object["uid"]
 
-        downloaded = simian.vendor.objaverse.load_objects([uid])
+        downloaded = objaverse.load_objects([uid])
 
     # Render the images
     render_scene(

--- a/simian/tests/__run__.py
+++ b/simian/tests/__run__.py
@@ -10,18 +10,17 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-files = os.listdir("tests")
+files = os.listdir("simian/tests")
 test_files = [file for file in files if file.endswith("_test.py")]
-
-# Append Simian to sys.path before importing from package
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../"))
 
 # Flag to track if any test has failed
 test_failed = False
 
 for test_file in test_files:
     print(f"Running tests in {test_file}...")
-    cmd = [sys.executable, f"tests/{test_file}"]
+    # get the module name from the file by removing .py
+    module_name = test_file[:-3]
+    cmd = [sys.executable, "-m", f"simian.tests.{module_name}"]
 
     if args.debug:
         print(f"Command: {' '.join(cmd)}")

--- a/simian/tests/background_test.py
+++ b/simian/tests/background_test.py
@@ -1,12 +1,7 @@
 import os
-import sys
-
-current_dir = os.path.dirname(os.path.abspath(__file__))
-simian_path = os.path.join(current_dir, "../")
-sys.path.append(simian_path)
 
 from unittest.mock import patch, MagicMock
-from simian.background import (
+from ..background import (
     get_hdri_path,
     get_background,
     set_background,
@@ -15,7 +10,7 @@ from simian.background import (
 )
 
 import bpy
-from simian.background import set_background
+from ..background import set_background
 
 
 def test_get_hdri_path():
@@ -75,7 +70,7 @@ def test_set_background():
 
     # Mocking dependencies
     with patch(
-        "simian.background.get_hdri_path",
+        "..background.get_hdri_path",
         return_value=os.path.join(background_base_path, "test_dataset/123.hdr"),
     ) as mock_get_path:
         with patch("os.path.exists", return_value=False):
@@ -173,7 +168,7 @@ def test_create_photosphere_material():
 
     # Mock the get_hdri_path function to return a known path
     with patch(
-        "simian.background.get_hdri_path",
+        "..background.get_hdri_path",
         return_value=os.path.join(background_base_path, "test_dataset/123.hdr"),
     ) as mock_get_path:
         # Mock the existence of the background image file

--- a/simian/tests/batch_test.py
+++ b/simian/tests/batch_test.py
@@ -1,11 +1,4 @@
-import os
-import sys
-
-current_dir = os.path.dirname(os.path.abspath(__file__))
-simian_path = os.path.join(current_dir, "../")
-sys.path.append(simian_path)
-
-from simian.batch import render_objects
+from ..batch import render_objects
 
 
 def test_render_objects():

--- a/simian/tests/camera_test.py
+++ b/simian/tests/camera_test.py
@@ -1,19 +1,12 @@
-import os
-import sys
 import math
 
-
-current_dir = os.path.dirname(os.path.abspath(__file__))
-simian_path = os.path.join(current_dir, "../")
-sys.path.append(simian_path)
-
 import bpy
-from simian.camera import (
+from ..camera import (
     create_camera_rig,
     set_camera_settings,
     position_camera,
 )
-from simian.scene import initialize_scene
+from ..scene import initialize_scene
 
 
 def test_create_camera_rig():

--- a/simian/tests/combiner_test.py
+++ b/simian/tests/combiner_test.py
@@ -7,8 +7,7 @@ from unittest.mock import patch, mock_open
 import random
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
-project_root = os.path.abspath(os.path.join(current_dir, ".."))
-sys.path.append(project_root)
+project_root = os.path.abspath(os.path.join(current_dir, "../../"))
 
 # Mock arguments with absolute paths
 mock_args = {
@@ -30,9 +29,9 @@ def mock_parse_args(*args, **kwargs):
     return argparse.Namespace(**mock_args)
 
 
-# Mock parse_args globally before importing simian.combiner
+# Mock parse_args globally before importing ..combiner
 with patch("argparse.ArgumentParser.parse_args", new=mock_parse_args):
-    from simian.combiner import (
+    from ..combiner import (
         read_json_file,
         generate_combinations,
         generate_stage_captions,
@@ -153,8 +152,7 @@ cap3d_captions_data = read_json_file(os.path.join(datasets_dir, "cap3d_captions.
 
 
 def test_combination_caption():
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(current_dir, "../combinations.json")
+    file_path = os.path.join(project_root, "combinations.json")
 
     with open(file_path, "r") as file:
         data = json.load(file)

--- a/simian/tests/new_camera_test.py
+++ b/simian/tests/new_camera_test.py
@@ -1,14 +1,8 @@
-import os
-import sys
 import bpy
 import math
 from mathutils import Vector
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
-combiner_path = os.path.join(current_dir, "../")
-sys.path.append(combiner_path)
-
-from simian.camera import create_camera_rig
+from ..camera import create_camera_rig
 
 
 def calculate_optimal_distance(camera, obj):

--- a/simian/tests/object_test.py
+++ b/simian/tests/object_test.py
@@ -1,13 +1,8 @@
-import sys
 import os
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
-simian_path = os.path.join(current_dir, "../")
-sys.path.append(simian_path)
-
-from simian.camera import create_camera_rig
-from simian.scene import initialize_scene
-from simian.object import (
+from ..camera import create_camera_rig
+from ..scene import initialize_scene
+from ..object import (
     delete_all_empties,
     get_hierarchy_bbox,
     join_objects_in_hierarchy,
@@ -73,7 +68,7 @@ def test_remove_small_geometry():
     initial_objects = lock_all_objects()
 
     # Path to the GLB file
-    glb_path = os.path.join(current_dir, "../", "examples", "dangling_parts.glb")
+    glb_path = os.path.join(current_dir, "../", "../", "examples", "dangling_parts.glb")
 
     # Load the model
     bpy.ops.import_scene.gltf(filepath=glb_path)

--- a/simian/tests/postprocessing_test.py
+++ b/simian/tests/postprocessing_test.py
@@ -1,13 +1,6 @@
 from unittest.mock import MagicMock
 
-import sys
-import os
-
-current_dir = os.path.dirname(os.path.abspath(__file__))
-simian_path = os.path.join(current_dir, "../")
-sys.path.append(simian_path)
-
-from simian.postprocessing import (
+from ..postprocessing import (
     setup_compositor_for_black_and_white,
     setup_compositor_for_cel_shading,
     setup_compositor_for_depth,

--- a/simian/tests/transform_test.py
+++ b/simian/tests/transform_test.py
@@ -1,13 +1,6 @@
 import math
-import os
-import sys
-import numpy as np
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
-combiner_path = os.path.join(current_dir, "../")
-sys.path.append(combiner_path)
-
-from simian.transform import (
+from ..transform import (
     degrees_to_radians,
     compute_rotation_matrix,
     apply_rotation,

--- a/simian/tests/worker_test.py
+++ b/simian/tests/worker_test.py
@@ -1,16 +1,11 @@
 import json
-import os
 import sys
 from unittest.mock import patch
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
-combiner_path = os.path.join(current_dir, "../")
-sys.path.append(combiner_path)
-
-from simian.worker import run_job
+from ..worker import run_job
 
 
-@patch("simian.worker.subprocess.run")
+@patch("..worker.subprocess.run")
 def test_run_job(mock_subprocess_run):
     combination_index = 0
     combination = {"objects": []}
@@ -35,7 +30,7 @@ def test_run_job(mock_subprocess_run):
     combination_str = json.dumps(combination)
     combination_str = '"' + combination_str.replace('"', '\\"') + '"'
 
-    command = f"{sys.executable} simian/render.py -- --width {width} --height {height} --combination_index {combination_index}"
+    command = f"{sys.executable} -m simian.render -- --width {width} --height {height} --combination_index {combination_index}"
     command += f" --output_dir {output_dir}"
     command += f" --hdri_path {hdri_path}"
     command += f" --start_frame {start_frame} --end_frame {end_frame}"

--- a/simian/worker.py
+++ b/simian/worker.py
@@ -46,7 +46,7 @@ def run_job(
     args += f" --start_frame {start_frame} --end_frame {end_frame}"
     args += f" --combination {combination}"
 
-    command = f"{sys.executable} simian/render.py -- {args}"
+    command = f"{sys.executable} -m simian.render -- {args}"
     logger.info(f"Worker running: {command}")
 
     subprocess.run(["bash", "-c", command], check=False)
@@ -63,12 +63,10 @@ def run_job(
             logger.info(e)
 
 
-if __name__ == "__main__":
+from distributaur.distributaur import create_from_config
 
-    from distributaur.core import register_function, app
+distributaur = create_from_config()
 
-    sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../"))
+celery = distributaur.app
 
-    celery = app
-
-    register_function(run_job)
+distributaur.register_function(run_job)

--- a/simian/worker.py
+++ b/simian/worker.py
@@ -66,7 +66,7 @@ def run_job(
 from distributaur.distributaur import create_from_config
 
 distributaur = create_from_config()
+distributaur.register_function(run_job)
 
 celery = distributaur.app
 
-distributaur.register_function(run_job)

--- a/simian/worker.py
+++ b/simian/worker.py
@@ -63,10 +63,14 @@ def run_job(
             logger.info(e)
 
 
-from distributaur.distributaur import create_from_config
+# only run this is this file was started by celery or run directly
+# check if celery is in sys.argv, it could be sys.argv[0] but might not be
+    
+if __name__ == "__main__" or any("celery" in arg for arg in sys.argv):
+    from distributaur.distributaur import create_from_config
 
-distributaur = create_from_config()
-distributaur.register_function(run_job)
+    distributaur = create_from_config()
+    distributaur.register_function(run_job)
 
-celery = distributaur.app
+    celery = distributaur.app
 


### PR DESCRIPTION
This PR changes quite a bit. First, we remove the sys.path.append so we don't need to worry about packages. So instead of calling python files directly, we invoke them by module name, i.e. `python -m simian.batch` instead of `python simian/batch.py`.

Also moved tests into simian/tests